### PR TITLE
Use full package manager path

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,10 +1,13 @@
 const path = require('path')
 const { execSync } = require('child_process')
+const which = require('which')
 const { isArray } = Array
 
 exports.onPostBuild = ({ store }, { files, ignore, config }) => {
   let { program: { useYarn, directory } } = store.getState()
-  let cmd = [useYarn ? 'yarn' : 'npm', 'percy', 'snapshot', path.resolve(directory, 'public')]
+
+  let manager = which.sync(useYarn ? 'yarn' : 'npm')
+  let cmd = [manager, 'percy', 'snapshot', path.resolve(directory, 'public')]
 
   if (files) {
     cmd = cmd.concat('--snapshot-files', [].concat(files).join(','))

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test": "mocha test.js"
   },
   "dependencies": {
-    "unist-util-visit": "^1.4.0"
   },
   "peerDependencies": {
     "@percy/agent": "^0.20.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-percy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A Gatsby plugin for automatically taking Percy snapshots after a build.",
   "repository": "github:percy/gatsby-plugin-percy",
   "author": "Perceptual Inc.",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "mocha test.js"
   },
   "dependencies": {
+    "which": "^2.0.2"
   },
   "peerDependencies": {
     "@percy/agent": "^0.20.0"

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const expect = require('expect')
 const mock = require('mock-require')
+const which = require('which')
 
 function execSyncMock(...args) {
   (execSyncMock.calls = execSyncMock.calls || []).push(args)
@@ -13,6 +14,8 @@ const { onPostBuild } = require('./gatsby-node')
 
 describe('onPostBuild', () => {
   let program, store = { getState: () => ({ program }) }
+  let yarn = which.sync('yarn')
+  let npm = which.sync('npm')
 
   beforeEach(() => {
     delete execSyncMock.calls
@@ -22,47 +25,47 @@ describe('onPostBuild', () => {
   it('calls `percy snapshot` with npm using the public path', () => {
     onPostBuild({ store }, {})
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe('npm percy snapshot public')
+    expect(execSyncMock.calls[0][0]).toBe(`${npm} percy snapshot public`)
   })
 
   it('calls `percy snapshot` with yarn using the public path', () => {
     program.useYarn = true
     onPostBuild({ store }, {})
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe('yarn percy snapshot public')
+    expect(execSyncMock.calls[0][0]).toBe(`${yarn} percy snapshot public`)
   })
 
   it('calls `percy snapshot` with the resolved public path', () => {
     program.directory = 'some/project/path'
     onPostBuild({ store }, {})
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe('npm percy snapshot some/project/path/public')
+    expect(execSyncMock.calls[0][0]).toBe(`${npm} percy snapshot some/project/path/public`)
   })
 
   it('calls `percy snapshot` with the `snapshot-files` option', () => {
     onPostBuild({ store }, { files: '*.html' })
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe('npm percy snapshot public --snapshot-files *.html')
+    expect(execSyncMock.calls[0][0]).toBe(`${npm} percy snapshot public --snapshot-files *.html`)
 
     onPostBuild({ store }, { files: ['*.html', '*.htm'] })
     expect(execSyncMock.calls).toHaveLength(2)
-    expect(execSyncMock.calls[1][0]).toBe('npm percy snapshot public --snapshot-files *.html,*.htm')
+    expect(execSyncMock.calls[1][0]).toBe(`${npm} percy snapshot public --snapshot-files *.html,*.htm`)
   })
 
   it('calls `percy snapshot` with the `ignore-files` option', () => {
     onPostBuild({ store }, { ignore: '*.html' })
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe('npm percy snapshot public --ignore-files *.html')
+    expect(execSyncMock.calls[0][0]).toBe(`${npm} percy snapshot public --ignore-files *.html`)
 
     onPostBuild({ store }, { ignore: ['*.html', '*.htm'] })
     expect(execSyncMock.calls).toHaveLength(2)
-    expect(execSyncMock.calls[1][0]).toBe('npm percy snapshot public --ignore-files *.html,*.htm')
+    expect(execSyncMock.calls[1][0]).toBe(`${npm} percy snapshot public --ignore-files *.html,*.htm`)
   })
 
   it('calls `percy snapshot` with the `config` option', () => {
     onPostBuild({ store }, { config: 'path/to/.percy.yml' })
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe('npm percy snapshot public --config path/to/.percy.yml')
+    expect(execSyncMock.calls[0][0]).toBe(`${npm} percy snapshot public --config path/to/.percy.yml`)
   })
 
   it('calls `percy snapshot` with multiple options', () => {
@@ -77,7 +80,7 @@ describe('onPostBuild', () => {
 
     expect(execSyncMock.calls).toHaveLength(1)
     expect(execSyncMock.calls[0][0]).toBe([
-      'yarn percy snapshot some/project/path/public',
+      `${yarn} percy snapshot some/project/path/public`,
       '--snapshot-files *.html',
       '--ignore-files *.htm',
       '--config path/to/.percy.yml'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,6 +2130,13 @@ which@1.3.1, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
+which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,25 +2083,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
-unist-util-is@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
-  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
-
-unist-util-visit-parents@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
-  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
-  dependencies:
-    unist-util-is "^3.0.0"
-
-unist-util-visit@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
-  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
-  dependencies:
-    unist-util-visit-parents "^2.0.0"
-
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"


### PR DESCRIPTION
## Purpose

This helps run either package manager cross-platform and will print a better error when the preferred one is missing.

## Approach

Use [node-which](https://github.com/npm/node-which) to get the full path to the package manager in a cross-platform way.

## Questions

Not entirely sure how `useYarn` is set internally by Gatsby. Should we use a try-catch and fallback to npm which should always be present if node is?