### PR TITLE
Use npx

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,8 +6,8 @@ const { isArray } = Array
 exports.onPostBuild = ({ store }, { files, ignore, config }) => {
   let { program: { useYarn, directory } } = store.getState()
 
-  let manager = which.sync(useYarn ? 'yarn' : 'npm')
-  let cmd = [manager, 'run', 'percy', 'snapshot', path.resolve(directory, 'public')]
+  let manager = which.sync(useYarn ? 'yarn' : 'npx')
+  let cmd = [manager, 'percy', 'snapshot', path.resolve(directory, 'public')]
 
   if (files) {
     cmd = cmd.concat('--snapshot-files', [].concat(files).join(','))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-percy",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Gatsby plugin for automatically taking Percy snapshots after a build.",
   "repository": "github:percy/gatsby-plugin-percy",
   "author": "Perceptual Inc.",

--- a/test.js
+++ b/test.js
@@ -15,57 +15,57 @@ const { onPostBuild } = require('./gatsby-node')
 describe('onPostBuild', () => {
   let program, store = { getState: () => ({ program }) }
   let yarn = which.sync('yarn')
-  let npm = which.sync('npm')
+  let npx = which.sync('npx')
 
   beforeEach(() => {
     delete execSyncMock.calls
     program = {}
   })
 
-  it('calls `percy snapshot` with npm using the public path', () => {
+  it('calls `percy snapshot` with npx using the public path', () => {
     onPostBuild({ store }, {})
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe(`${npm} run percy snapshot public`)
+    expect(execSyncMock.calls[0][0]).toBe(`${npx} percy snapshot public`)
   })
 
   it('calls `percy snapshot` with yarn using the public path', () => {
     program.useYarn = true
     onPostBuild({ store }, {})
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe(`${yarn} run percy snapshot public`)
+    expect(execSyncMock.calls[0][0]).toBe(`${yarn} percy snapshot public`)
   })
 
   it('calls `percy snapshot` with the resolved public path', () => {
     program.directory = 'some/project/path'
     onPostBuild({ store }, {})
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe(`${npm} run percy snapshot some/project/path/public`)
+    expect(execSyncMock.calls[0][0]).toBe(`${npx} percy snapshot some/project/path/public`)
   })
 
   it('calls `percy snapshot` with the `snapshot-files` option', () => {
     onPostBuild({ store }, { files: '*.html' })
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe(`${npm} run percy snapshot public --snapshot-files *.html`)
+    expect(execSyncMock.calls[0][0]).toBe(`${npx} percy snapshot public --snapshot-files *.html`)
 
     onPostBuild({ store }, { files: ['*.html', '*.htm'] })
     expect(execSyncMock.calls).toHaveLength(2)
-    expect(execSyncMock.calls[1][0]).toBe(`${npm} run percy snapshot public --snapshot-files *.html,*.htm`)
+    expect(execSyncMock.calls[1][0]).toBe(`${npx} percy snapshot public --snapshot-files *.html,*.htm`)
   })
 
   it('calls `percy snapshot` with the `ignore-files` option', () => {
     onPostBuild({ store }, { ignore: '*.html' })
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe(`${npm} run percy snapshot public --ignore-files *.html`)
+    expect(execSyncMock.calls[0][0]).toBe(`${npx} percy snapshot public --ignore-files *.html`)
 
     onPostBuild({ store }, { ignore: ['*.html', '*.htm'] })
     expect(execSyncMock.calls).toHaveLength(2)
-    expect(execSyncMock.calls[1][0]).toBe(`${npm} run percy snapshot public --ignore-files *.html,*.htm`)
+    expect(execSyncMock.calls[1][0]).toBe(`${npx} percy snapshot public --ignore-files *.html,*.htm`)
   })
 
   it('calls `percy snapshot` with the `config` option', () => {
     onPostBuild({ store }, { config: 'path/to/.percy.yml' })
     expect(execSyncMock.calls).toHaveLength(1)
-    expect(execSyncMock.calls[0][0]).toBe(`${npm} run percy snapshot public --config path/to/.percy.yml`)
+    expect(execSyncMock.calls[0][0]).toBe(`${npx} percy snapshot public --config path/to/.percy.yml`)
   })
 
   it('calls `percy snapshot` with multiple options', () => {
@@ -80,7 +80,7 @@ describe('onPostBuild', () => {
 
     expect(execSyncMock.calls).toHaveLength(1)
     expect(execSyncMock.calls[0][0]).toBe([
-      `${yarn} run percy snapshot some/project/path/public`,
+      `${yarn} percy snapshot some/project/path/public`,
       '--snapshot-files *.html',
       '--ignore-files *.htm',
       '--config path/to/.percy.yml'


### PR DESCRIPTION
## Purpose

`npm run` only runs _scripts_ while `yarn run` runs scripts _and installed packages_.

## Approach

Remove `run` and just use `npx` which has been available since npm 5.2