### PR TITLE
security: harden CI workflows — pin actions, scope tokens, fix dispatch injection (PER-8750/8752/8753)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,10 +2,15 @@ name: Changelog
 on:
   push:
     branches: [master]
+permissions:
+  contents: read
 jobs:
   update_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,18 +1,21 @@
 name: Lint
 on: push
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: v1/${{ runner.os }}/node-14/${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,15 @@ name: Release
 on:
   release:
     types: [published]
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,11 +2,16 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '0 19 * * 2'
+permissions:
+  contents: read
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           stale-issue-message: >-
             This issue is stale because it has been open for more than 14 days with no activity.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
         required: false
         type: string
         default: master
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -16,7 +19,7 @@ jobs:
         node: [14]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions-ecosystem/action-regex-match@v2
+      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
         id: regex-match
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
@@ -25,14 +28,14 @@ jobs:
       - name: Break on invalid branch name
         run: exit 1
         if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: ${{ matrix.node }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: v1/${{ runner.os }}/node-${{ matrix.node }}/${{ hashFiles('**/yarn.lock') }}
@@ -40,16 +43,19 @@ jobs:
       - run: yarn
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          CLI_BRANCH: ${{ github.event.inputs.branch }}
+          WORKSPACE: ${{ github.workspace }}
         run: |
           cd /tmp
-          git clone --branch ${{ github.event.inputs.branch }} --depth 1 https://github.com/percy/cli
+          git clone --branch "$CLI_BRANCH" --depth 1 https://github.com/percy/cli
           cd cli
           PERCY_PACKAGES=`find packages -mindepth 1 -maxdepth 1 -type d | sed -e 's/packages/@percy/g' | tr '\n' ' '`
           git log -1
           yarn
           yarn build
           yarn global:link
-          cd ${{ github.workspace }} 
+          cd "$WORKSPACE"
           yarn remove @percy/cli && yarn link `echo $PERCY_PACKAGES`
           npx percy --version
       - run: yarn test:coverage


### PR DESCRIPTION
## Summary
Breaks the CI-injection and supply-chain-escalation legs of the gatsby-plugin-percy chains (deadline 2026-06-21).

| Chain | Entry |
|-------|-------|
| [PER-8750](https://browserstack.atlassian.net/browse/PER-8750) (C-001) | loader-utils proto-pollution RCE in CI → npm poisoning via over-scoped tokens |
| [PER-8752](https://browserstack.atlassian.net/browse/PER-8752) (C-003) | mutable-tag hijack of regex-match action → branch-name shell injection → token exfil |
| [PER-8753](https://browserstack.atlassian.net/browse/PER-8753) (C-004) | workflow_dispatch shell injection → over-scoped GITHUB_TOKEN |

## Changes
- **SHA-pin** every action (`checkout`, `setup-node`, `cache`, `release-drafter`, `action-regex-match`, `stale`).
- **Least-privilege `permissions`** on every workflow (top-level `contents: read`; `changelog` → contents/PR write; `stale` → issues/PR write) — removes the over-scoped `GITHUB_TOKEN` the chains exfiltrate.
- **Env-bind + quote** the `workflow_dispatch` branch input in `test.yml` (was interpolated into the `git clone` shell) — closes the C-003/C-004 shell-injection.

This severs the npm-publish / repo-takeover escalation that the loader-utils (C-001) and `@babel/traverse` CVE-2023-45133 (C-002, [PER-8751](https://browserstack.atlassian.net/browse/PER-8751)) build-RCE chains depend on.

## Verification
All workflow YAMLs parse; zero unpinned `uses:`; every workflow declares `permissions:`; dispatch branch no longer interpolated inline.

## Scope note (flagged)
The underlying **dev/build-tree CVEs** — `loader-utils` 1.4.0/2.0.2 (C-001) and `@babel/traverse` 7.18.11 (C-002) — are transitive deps of `gatsby`/`webpack`/`babel`. A blanket yarn `resolution` across loader-utils' three majors (1.x/2.x/3.x) risks breaking the gatsby build, so the dep bump is flagged as a follow-up (gatsby / build-tooling upgrade) rather than force-resolved here. The CI hardening above removes the escalation path that makes these chains High.

Closes the CI legs of PER-8750/8752/8753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8750]: https://browserstack.atlassian.net/browse/PER-8750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8752]: https://browserstack.atlassian.net/browse/PER-8752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8753]: https://browserstack.atlassian.net/browse/PER-8753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8751]: https://browserstack.atlassian.net/browse/PER-8751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ